### PR TITLE
Clarify differences with JSX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,10 +15,7 @@ t7 provides designers and developers with a way to create awesome
 templates that anyone with JavaScript knowledge can easily understand.
 Long gone are the days of having to learn something like Mustache, Handlebars, Jade or Underscore.
 
-Unlike JSX, t7 is fully web compliant, resulting in templates that can easily be linted.
-Furthermore, IDEs should play nicely with the syntax and there isn't a need to setup
-in-browser transformers or NodeJS transpilers to start developing.
-
+Unlike JSX, t7 relies exclusively on ES 2015 features, so you can use any ES 2015 compliant build tools, linters, IDEs or syntax highlighting schemes, without worrying about transpiling JSX.
 
 ## Installing
 


### PR DESCRIPTION
I understand you might not want to take this, but I wanted to clarify something that seemed off to me.

>resulting in templates that can easily be linted

For any practical purposes, JSX has been possible to lint for a few years now, first with [JSXHint](https://github.com/STRML/JSXHint/), and now with ESLint that supports JSX out of the box. The claim is also a bit misleading because “linting t7” won't lint the string contents—just the interpolated expressions. Whereas with JSX linting as implemented in JSXHint or ESLint, you get parse errors if your tree is malformed.

>there isn't a need to setup in-browser transformers or NodeJS transpilers to start developing.

I removed this sentence too. First, nobody in the real world sets up in-browser transformers to develop with JSX. I'm sure you know that—it just feels misleading to even mention that in the comparison. Secondly, this sentence makes it sound like you don't need *any* transpilers to use t7 today in the browsers. (Is anybody writing virtual DOM server-only apps?) But this isn't the case. Since t7 requires ES 2015, it actually *needs* a transpiler like Babel today. And Babel supports JSX. So it's unfair to say JSX requires transpilers but t7 lets you start developing without them—at least not until most browsers support [template strings](https://kangax.github.io/compat-table/es6/#test-template_strings).

I think t7 is a fine library and I mean well. Some of my arguments may be invalid in a year or two, but I think they are valid as of today. Please feel free to close if you consider this inaccurate or inappropriate. Keep up the good work!