### PR TITLE
enable basic react-native support

### DIFF
--- a/t7.js
+++ b/t7.js
@@ -11,7 +11,7 @@ var t7 = (function() {
   "use strict";
 
   //we store created functions in the cache (key is the template string)
-  var isBrowser = typeof window != "undefined" && document != null;
+  var isBrowser = typeof window != "undefined" && typeof document != null && navigator.product != 'ReactNative';
   var docHead = null;
   //to save time later, we can pre-create a props object structure to re-use
   var output = null;
@@ -506,11 +506,15 @@ var t7 = (function() {
   function applyValues(string, values) {
     var index = 0;
     var re = /__\$props__\[([0-9]*)\]/;
+
     var placeholders = string.match(/__\$props__\[([0-9]*)\]/g);
-    for (var i = 0; i < placeholders.length; i++) {
-      index = re.exec(placeholders[i])[1];
-      string = string.replace(placeholders[i], values[index]);
-    }
+    if (placeholders !=null)
+      {
+        for (var i = 0; i < placeholders.length; i++) {
+          index = re.exec(placeholders[i])[1];
+          string = string.replace(placeholders[i], values[index]);
+        }
+      }
     return string;
   };
 


### PR DESCRIPTION
Using react 0.20.0 on android. 
With the small changes now t7 can be loaded up.
Change 1)   added another condition to browser check. If ReactNative is present, isBrowser will be set to false

Change 2) in applyValues function, I had to introduce an if not null condition for 'placeholders' variable.
Because it was 'null' if there were no replacement values present in my tests.

Even with these changes, however the library does not work for me.
It appears that it cannot parse a valid JSX such as
```

  return (t7`
      <View style={styles.list}>
      <Text  style={styles.instructions}
      {...route.passProps}
      navigator={navigator}
      >
      
      My Text
      </Text>
	<ToolbarAndroid
            style={styles.toolbar}
            title={route.title}
            
            onIconClicked={() => navigator.pop()}
	/> 
      </View>
    `);

```

> 
> The error I am getting is:
> Expected corresponding t7 closing tag for ToobarAndroid
Which is clearly is wrong, because JSX allows single closing tags.
But just in case, I had tried to close with </ToolbarAndroid> and still did not work.

Attaching my js index test javascript
[rn-android-with-t7.zip](https://github.com/trueadm/t7/files/149220/rn-android-with-t7.zip)

