### PR TITLE
Adds support for splats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,19 @@ as `<Foo></Foo>` this ensures that the component gets picked up by t7 properly.
 
 - [Handling nested React components](examples/react-complex-components.html)
 
+## Splats
+Splat syntax (`...`) is supported if you would like to pass multiple props to an element. Insertion order
+of the props is maintained with subsequent values overriding preceeding ones.
+
+```javascript
+const a = 'a';
+const props = { b: 'b', c: 'NOT C' };
+const moreProps = { d: 'd' };
+
+t7`<div a=${a} b='NOT B' ...${props} c='c' ...${moreProps}></div>`;
+// => div will receive { a: 'a', b: 'b', c: 'c', d: 'd' }
+```
+
 ## Control Flow
 
 To help reduce boilerplate and speed up development, t7 comes with a few essential

--- a/t7.js
+++ b/t7.js
@@ -6,7 +6,6 @@
   By Dominic Gannaway
 
 */
-/* eslint-disable */
 
 var t7 = (function() {
   "use strict";
@@ -807,8 +806,6 @@ var t7 = (function() {
         if (isBrowser === true) {
           scriptString = 't7._cache["' + templateKey + '"]=function(__$props__, __$components__, t7)';
           scriptString += '{"use strict";return ' + scriptCode + '}';
-          console.log(scriptCode);
-
           addNewScriptFunction(scriptString, templateKey);
         } else {
           t7._cache[templateKey] = new Function('"use strict";var __$props__ = arguments[0];var __$components__ = arguments[1];var t7 = arguments[2];return ' + scriptCode);

--- a/t7.js
+++ b/t7.js
@@ -178,7 +178,7 @@ var t7 = (function() {
             } else {
               templateParams.push("var " + nodeName + i + " = Inferno.dom.createElement('" + child.tag + "');");
               if (child.assignments) {
-                var infernoHelper = infernoTemplateHelper.bind(null, child, nodeName + i, templateValues, templateParams, valueCounter);
+                var infernoHelper = infernoTemplateHelper.bind(null, child, nodeName + i, templateValues, templateParams, valueCounter, null);
                 templateParams.push("Inferno.dom.addAttributes(" + nodeName + i + ", " + joinAttrs(root.assignments, infernoHelper) + ");");
               }
               if (child.children) {
@@ -238,7 +238,7 @@ var t7 = (function() {
   };
 
   function infernoTemplateHelper (root, rootElement, templateValues, templateParams, valueCounter, propRefs, name, val) {
-    valueName = "fragment.templateValues[" + valueCounter.index + "]";
+    var valueName = "fragment.templateValues[" + valueCounter.index + "]";
     if (!propRefs) {
       switch (name) {
         case "class":
@@ -409,7 +409,7 @@ var t7 = (function() {
         } else {
           templateParams.push("var root = Inferno.dom.createElement('" + root.tag + "');");
           if (root.assignments) {
-            var helper = infernoTemplateHelper.bind(null, root, "root", templateValues, templateParams, valueCounter);
+            var helper = infernoTemplateHelper.bind(null, root, "root", templateValues, templateParams, valueCounter, null);
             templateParams.push("Inferno.dom.addAttributes(root, " + joinAttrs(root.assignments, helper) + ");");
           }
         }

--- a/tests/universal-tests.js
+++ b/tests/universal-tests.js
@@ -77,6 +77,19 @@ describe("Universal tests", function() {
     assert(output === expected);
   });
 
+  it('should handle the splat example', function() {
+    const a = 'a';
+    const props = { b: 'b', c: 'NOT C' };
+    const moreProps = { d: 'd' };
+
+    const input = t7`<div a=${a} b='NOT B' ...${props} c='c' ...${moreProps}></div>`;
+
+    expect(input).to.deep.equal({
+      tag: 'div',
+      attrs: { a: 'a', b: 'b', c: 'c', d: 'd' }
+    });
+  });
+
   it('should throw an error upon when there is a missing closing tag', function() {
     var fooBar = "Foo";
     var test = "123"


### PR DESCRIPTION
Hello,

Here is my PR for the splat feature as discussed in issue #23. I have given it a shot. Wow, that stringed function approach in this project. I assume it is for that sweet performance, but it is a brain scrambler.

To summarize, this modification not tracks all the attributes in an array called `assignments` on the root, instead of `root.attrs` as insertion order becomes important. The array contains a tuple `[name, val]` in case of normal attributes and just the `val` to be assigned in case of a splat.

Later on it is up to a new function called `joinAttrs` to put this all together and it does that by sequencing the assignments into a single `Object.assign` call.  

I also had to abstract the iteration over the attributes so the old `buildAttrs` and `buildInfernoAttrs` variants were inlined into the `joinAttrs` function. In case of inferno the second argument of `joinAttrs` receives a bound callback where all the template sideeffect can happen. I have called this the `infernoTemplateHelper`.

All tests pass, including a new one for the splats. I also added a description to the readme. 

Hope that all makes sense. Please feel free to ask if something is unclear.